### PR TITLE
Fixed player movement on Raspberry Pi. Looks like the Pi defaults to …

### DIFF
--- a/src/display.c
+++ b/src/display.c
@@ -531,8 +531,8 @@ void showplayer(void)
  * players when walking into walls) if player walks off screen or into wall
  *
  */
-char diroffx[] = { 0,  0, 1,  0, -1,  1, -1, 1, -1 };
-char diroffy[] = { 0,  1, 0, -1,  0, -1, -1, 1,  1 };
+short diroffx[] = { 0,  0, 1,  0, -1,  1, -1, 1, -1 };
+short diroffy[] = { 0,  1, 0, -1,  0, -1, -1, 1,  1 };
 
 int moveplayer(int dir)
 	/*	from = present room #  direction = [1-north]

--- a/src/extern.h
+++ b/src/extern.h
@@ -367,7 +367,8 @@ extern char nch[], ndgg[], ckpflag, monstlevel[];
 extern char nlpts[], nplt[],nsw[], mail,boldon, splev[];
 extern char potprob[], predostuff, scprob[], spelknow[], do_fork, sex;
 extern char spelweird[MAXMONST+8][SPNUM], wizard;
-extern char diroffx[],diroffy[],hitflag,hit2flag,hit3flag;
+extern short diroffx[],diroffy[];
+extern char hitflag,hit2flag,hit3flag;
 extern char rmst, lasthx,lasthy,lastpx,lastpy;
 extern char ramboflag;
 


### PR DESCRIPTION
Sure thing! I meant to do that but I'm still learning github... 


  | Fixed player movement on Raspberry Pi. Looks like the Pi defaults to unsigned
char type, but directional offset char arrays diroffx[] and diroffy[]
contain negative values, so player could only move down and right. Changing
to short fixes this issue.